### PR TITLE
Ctrl + click issue was fixed

### DIFF
--- a/src/app/iatec-layout/menu/menu-item.component.ts
+++ b/src/app/iatec-layout/menu/menu-item.component.ts
@@ -42,7 +42,8 @@ export class MenuItemComponent {
             this.setActive(!this.item.active);
         }
         else {
-            this.item.semiActive = true;
+            if (!ev.ctrlKey)
+                this.item.semiActive = true;
         }
         this.clickMenu.next(<ItemEventInterface>{ mouseEvent: ev, item: item.menuItemModel });
     }

--- a/src/app/iatec-layout/menu/menu-root.component.ts
+++ b/src/app/iatec-layout/menu/menu-root.component.ts
@@ -306,8 +306,10 @@ export class MenuRootComponent implements ControlValueAccessor, OnDestroy {
     }
 
     public onClickMenuFloat(item: ItemEventInterface): void {
-        this.resetMenusActive();
-        this.setMenuParentsActive(this.value, item.item.id);
+        if (!item.mouseEvent.ctrlKey) {
+            this.resetMenusActive();
+            this.setMenuParentsActive(this.value, item.item.id);
+        }
         this.onClickMenu(item);
     }
 

--- a/src/app/iatec-layout/menu/tree-menu.component.ts
+++ b/src/app/iatec-layout/menu/tree-menu.component.ts
@@ -35,7 +35,7 @@ export class TreeMenuComponent implements ControlValueAccessor {
     public onClick(itemEvent: ItemEventInterface): void {
         let item = itemEvent.item;
         this.menuItemComponents.forEach(mic => {
-            if (mic.item.menuItemModel != item)
+            if (!itemEvent.mouseEvent.ctrlKey && mic.item.menuItemModel != item)
                 mic.setActive(mic.item.menuItemModel == item);
         });
 


### PR DESCRIPTION
Added validation for ctrl+click event. Now it doesn't mark the item as active when we use it with the ctrl key. It's working with tree-menu and float-menu.